### PR TITLE
DB증권 WebSocket extra_headers 호환성 수정 및 requirements 정리

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pydantic==2.*                 # 최신 v2 유지
 requests==2.32.*
 python-dotenv==1.0.*          # (선택) 로컬 .env 사용 시
 yfinance>=0.2.40
-httpx==0.27.0                 # 버전 통일 (권장 안정판)
-websocket-client>=1.5.0       # DB증권 WebSocket client (extra_headers 지원)
+httpx==0.27.0
+websocket-client==1.7.0
 pytz>=2023.3                  # Timezone handling for trading sessions
 holidays>=0.57                # 휴일 처리 라이브러리


### PR DESCRIPTION
## Summary
- Reworked the DB증권 WebSocket monitor to create connections with `websocket-client` using header lists for compatibility with older deployments and adapted the async loop to run the blocking client safely in threads.
- Added defensive connection lifecycle handling, including timeout configuration, byte-to-string decoding, and graceful shutdown to keep the monitor resilient when reconnecting.
- Pinned `websocket-client` at 1.7.0 and kept a single `httpx==0.27.0` entry to avoid version drift.

## Testing
- pytest *(fails: async test plugin missing in the current environment)*
- timeout 5 uvicorn main:app --port 8000


------
https://chatgpt.com/codex/tasks/task_e_68e01e8412f48326bdb93d69bffd5e4d