### PR TITLE
Enhance DB secret masking and extend unit tests

### DIFF
--- a/services/dbsec_ws.py
+++ b/services/dbsec_ws.py
@@ -24,6 +24,30 @@ from utils.token_manager import get_token_manager
 logger = logging.getLogger(__name__)
 
 
+def mask_secret(value: Optional[str]) -> str:
+    """Mask sensitive credentials for safe logging."""
+    # 입력 값이 비어 있으면 완전 마스킹 처리
+    if value is None:
+        return "***"
+
+    try:
+        if isinstance(value, bytes):
+            value = value.decode("utf-8", "ignore")
+        elif not isinstance(value, str):
+            value = str(value)
+    except Exception as error:  # pragma: no cover - 방어적 로깅
+        logger.warning("Failed to normalize secret for masking: %s", error)
+        return "***"
+
+    cleaned = value.strip()
+    if not cleaned:
+        return "***"
+
+    if len(cleaned) > 6:
+        return f"{cleaned[:4]}***{cleaned[-2:]}"
+    return "***"
+
+
 class KOSPI200FuturesMonitor:
     """KOSPI200 Futures real-time monitor with anomaly detection"""
     

--- a/tests/test_dbsec_module.py
+++ b/tests/test_dbsec_module.py
@@ -18,7 +18,11 @@ os.environ['SENTINEL_BASE_URL'] = 'https://test.sentinel.com'
 os.environ['SENTINEL_KEY'] = 'test_sentinel_key'
 
 from utils.token_manager import DBSecTokenManager, get_token_manager
-from services.dbsec_ws import KOSPI200FuturesMonitor, get_futures_monitor
+from services.dbsec_ws import (
+    KOSPI200FuturesMonitor,
+    get_futures_monitor,
+    mask_secret,
+)
 
 
 class TestTokenManager:
@@ -298,6 +302,24 @@ class TestWebSocketReconnection:
                 
                 # Verify reconnection was attempted
                 assert monitor.reconnect_attempts > 0
+
+
+class TestSecretMasking:
+    """Test masking utility for sensitive secrets."""
+
+    def test_mask_secret_with_long_value(self):
+        """Ensure long secrets reveal prefix and suffix only."""
+        secret = "abcd1234ef"
+        masked = mask_secret(secret)
+
+        assert masked == "abcd***ef"
+
+    def test_mask_secret_with_short_value(self):
+        """Ensure short secrets remain fully masked."""
+        secret = "12345"
+        masked = mask_secret(secret)
+
+        assert masked == "***"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- update the DB Securities WebSocket utility masking helper to expose only the first four and last two characters of long secrets while keeping short values fully masked
- add dedicated unit coverage that verifies the updated masking behaviour alongside the existing DB Securities module tests

## Testing
- pytest *(fails: environment lacks pytest-asyncio support for async tests)*

------
https://chatgpt.com/codex/tasks/task_e_68e0e7b29ca0832680cf59b0e2c4e67d