### PR TITLE
Refactor masking utilities into shared helper

### DIFF
--- a/services/dbsec_ws.py
+++ b/services/dbsec_ws.py
@@ -19,6 +19,7 @@ from websocket._exceptions import (
 )
 import requests
 
+from utils.masking import redact_headers, redact_ws_url
 from utils.token_manager import get_token_manager
 
 logger = logging.getLogger(__name__)
@@ -48,7 +49,10 @@ class KOSPI200FuturesMonitor:
         self.buffer_size = buffer_size
         
         if self.enabled:
-            logger.info(f"[DB증권] K200 Futures Monitor ENABLED - WebSocket URL: {self.ws_url}")
+            logger.info(
+                "[DB증권] K200 Futures Monitor ENABLED - WebSocket URL: %s",
+                redact_ws_url(self.ws_url),
+            )
         else:
             logger.warning("[DB증권] K200 Futures Monitor DISABLED (mock mode) - no WebSocket connection")
         
@@ -150,14 +154,17 @@ class KOSPI200FuturesMonitor:
         })
         ws_url = urlunparse(parsed_url._replace(query=urlencode(query_params)))
 
-        logger.info(f"Connecting to WebSocket: {ws_url}")
+        logger.info("Connecting to WebSocket: %s", redact_ws_url(ws_url))
 
         headers: Dict[str, str] = {}
         send_auth_header = os.getenv("DBSEC_WS_SEND_AUTH_HEADER", "false").lower() in ("1", "true", "yes")
         if send_auth_header:
             token_type = getattr(token_manager, "token_type", "Bearer")
             headers["Authorization"] = f"{token_type} {access_token}"
-            logger.debug("Including Authorization header for WebSocket handshake")
+            logger.debug(
+                "Including Authorization header for WebSocket handshake: %s",
+                redact_headers(headers),
+            )
 
         header_list = [f"{k}: {v}" for k, v in headers.items()]
 

--- a/test_token.py
+++ b/test_token.py
@@ -17,6 +17,7 @@ logging.basicConfig(
 # Add parent directory to path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
+from utils.masking import mask_secret, redact_dict
 from utils.token_manager import DBSecTokenManager
 
 
@@ -41,8 +42,8 @@ async def test_token_request():
         return
     
     print(f"📍 Base URL: {base_url}")
-    print(f"🔑 App Key: {app_key[:4]}...{app_key[-4:] if len(app_key) > 8 else 'SHORT'}")
-    print(f"🔒 Secret: {'*' * len(app_secret)} (length: {len(app_secret)})")
+    print(f"🔑 App Key: {mask_secret(app_key)}")
+    print(f"🔒 Secret: {mask_secret(app_secret)} (length: {len(app_secret)})")
     print("="*60)
     
     # Create token manager
@@ -63,7 +64,7 @@ async def test_token_request():
     
     if token:
         print("\n✅ SUCCESS! Token acquired")
-        print(f"📝 Token: {token[:20]}...")
+        print(f"📝 Token: {mask_secret(token, visible=6)}")
         print(f"🕐 Expires at: {manager.expires_at}")
         print(f"📋 Type: {manager.token_type}")
     else:
@@ -74,8 +75,9 @@ async def test_token_request():
     
     # Health check
     health = await manager.health_check()
+    redacted_health = redact_dict(health)
     print("\n📊 Health Check:")
-    for key, value in health.items():
+    for key, value in redacted_health.items():
         print(f"   {key}: {value}")
     
     print("="*60)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,19 @@
+"""Utility package exports."""
+
+from .masking import (
+    SENSITIVE_KEYS,
+    mask_secret,
+    redact_dict,
+    redact_headers,
+    redact_kv,
+    redact_ws_url,
+)
+
+__all__ = [
+    "SENSITIVE_KEYS",
+    "mask_secret",
+    "redact_dict",
+    "redact_headers",
+    "redact_kv",
+    "redact_ws_url",
+]

--- a/utils/masking.py
+++ b/utils/masking.py
@@ -1,0 +1,107 @@
+"""Utility helpers for masking sensitive values in logs and telemetry."""
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping, Sequence
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+
+# 민감한 키 식별을 위한 기준 목록
+SENSITIVE_KEYS: Sequence[str] = (
+    "secret",
+    "token",
+    "password",
+    "api_key",
+    "apikey",
+    "appkey",
+    "app_key",
+    "appsecret",
+    "app_secret",
+    "appsecretkey",
+    "authorization",
+    "bearer",
+    "signature",
+    "sentinel_key",
+    "connector_secret",
+)
+
+
+def _is_sensitive_key(key: str) -> bool:
+    """Return True when the provided key represents a sensitive value."""
+    key_lower = key.lower()
+    return any(sensitive in key_lower for sensitive in SENSITIVE_KEYS)
+
+
+def mask_secret(value: Any, visible: int = 4) -> str:
+    """Mask a sensitive value while leaving a limited prefix/suffix visible."""
+    if value is None:
+        return ""
+
+    # 문자열화 후 마스킹 처리
+    value_str = str(value)
+    if value_str == "":
+        return ""
+
+    if visible <= 0 or len(value_str) <= visible * 2:
+        return "*" * len(value_str)
+
+    prefix = value_str[:visible]
+    suffix = value_str[-visible:]
+    masked_length = max(len(value_str) - (visible * 2), 0)
+    return f"{prefix}{'*' * masked_length}{suffix}"
+
+
+def redact_kv(key: str, value: Any, visible: int = 4) -> Any:
+    """Redact the provided key/value pair when the key is sensitive."""
+    if _is_sensitive_key(key):
+        return mask_secret(value, visible=visible)
+    return value
+
+
+def redact_ws_url(url: str, visible: int = 4) -> str:
+    """Redact sensitive query parameters contained in a WebSocket URL."""
+    if not url:
+        return url
+
+    parsed = urlparse(url)
+    if not parsed.query:
+        return url
+
+    # 쿼리 파라미터 마스킹
+    redacted_params = [
+        (key, redact_kv(key, value, visible=visible))
+        for key, value in parse_qsl(parsed.query, keep_blank_values=True)
+    ]
+    redacted_query = urlencode(redacted_params)
+    return urlunparse(parsed._replace(query=redacted_query))
+
+
+def redact_headers(headers: Mapping[str, Any], visible: int = 4) -> Dict[str, Any]:
+    """Return a copy of headers with sensitive values masked."""
+    return {key: redact_kv(key, value, visible=visible) for key, value in headers.items()}
+
+
+def redact_dict(data: Any, visible: int = 4) -> Any:
+    """Recursively redact sensitive keys within a mapping or iterable structure."""
+    if isinstance(data, Mapping):
+        return {
+            key: redact_dict(value, visible=visible)
+            if not _is_sensitive_key(key)
+            else mask_secret(value, visible=visible)
+            for key, value in data.items()
+        }
+    if isinstance(data, list):
+        return [redact_dict(item, visible=visible) for item in data]
+    if isinstance(data, tuple):
+        return tuple(redact_dict(item, visible=visible) for item in data)
+    if isinstance(data, set):
+        return {redact_dict(item, visible=visible) for item in data}
+    return data
+
+
+__all__ = [
+    "SENSITIVE_KEYS",
+    "mask_secret",
+    "redact_kv",
+    "redact_ws_url",
+    "redact_headers",
+    "redact_dict",
+]


### PR DESCRIPTION
## Summary
- add a reusable masking helper module under utils to centralize redaction logic
- update the DBSEC websocket service to log redacted URLs and headers via the shared helpers
- reuse the masking helpers in the token test script for consistent secret redaction

## Testing
- pytest tests/test_dbsec_module.py *(fails: ModuleNotFoundError: No module named 'utils')*

------
https://chatgpt.com/codex/tasks/task_e_68e0e7b7a0dc8326aa4df27609239eed