### PR TITLE
Tighten secret masking to 4-***-2 format

### DIFF
--- a/test_token.py
+++ b/test_token.py
@@ -64,7 +64,7 @@ async def test_token_request():
     
     if token:
         print("\n✅ SUCCESS! Token acquired")
-        print(f"📝 Token: {mask_secret(token, visible=6)}")
+        print(f"📝 Token: {mask_secret(token)}")
         print(f"🕐 Expires at: {manager.expires_at}")
         print(f"📋 Type: {manager.token_type}")
     else:


### PR DESCRIPTION
## Summary
- update the masking helpers to enforce the 4-***-2 pattern for long secrets and keep shorter values fully redacted
- adjust token tooling to use the revised masking helper interface

## Testing
- PYTHONPATH=. pytest tests/test_dbsec_module.py -k secret

------
https://chatgpt.com/codex/tasks/task_e_68e0f225c29c8326b35cfd5eb825397b