### PR TITLE
Refactor masking utilities and tighten sensitive logging

### DIFF
--- a/routers/dbsec.py
+++ b/routers/dbsec.py
@@ -7,6 +7,7 @@ from typing import Dict, Any, List, Optional
 from fastapi import APIRouter, HTTPException, BackgroundTasks
 from pydantic import BaseModel
 
+from utils.masking import redact_dict
 from utils.token_manager import get_token_manager, init_token_manager, shutdown_token_manager
 from services.dbsec_ws import get_futures_monitor, start_futures_monitoring, stop_futures_monitoring
 
@@ -347,7 +348,7 @@ def alert_callback(alert_data: Dict[str, Any]):
     
     This can be used to integrate with existing Sentinel alert mechanisms
     """
-    logger.info(f"DB증권 Alert callback triggered: {alert_data}")
+    logger.info("DB증권 Alert callback triggered: %s", redact_dict(alert_data))
     
     # Here you could add integration with existing Sentinel alert system
     # For example, sending to Telegram, Discord, etc.
@@ -362,7 +363,7 @@ def alert_callback(alert_data: Dict[str, Any]):
         "source": "dbsec"
     }
     
-    logger.info(f"Formatted Sentinel alert: {sentinel_alert}")
+    logger.info("Formatted Sentinel alert: %s", redact_dict(sentinel_alert))
 
 
 # Initialize alert callback

--- a/services/dbsec_ws.py
+++ b/services/dbsec_ws.py
@@ -19,36 +19,10 @@ from websocket._exceptions import (
 )
 import requests
 
-from utils.masking import redact_headers, redact_ws_url
+from utils.masking import mask_secret, redact_headers, redact_ws_url
 from utils.token_manager import get_token_manager
 
 logger = logging.getLogger(__name__)
-
-
-def mask_secret(value: Optional[str]) -> str:
-    """Mask sensitive credentials for safe logging."""
-    # 입력 값이 비어 있으면 완전 마스킹 처리
-    if value is None:
-        return "***"
-
-    try:
-        if isinstance(value, bytes):
-            value = value.decode("utf-8", "ignore")
-        elif not isinstance(value, str):
-            value = str(value)
-    except Exception as error:  # pragma: no cover - 방어적 로깅
-        logger.warning("Failed to normalize secret for masking: %s", error)
-        return "***"
-
-    cleaned = value.strip()
-    if not cleaned:
-        return "***"
-
-    if len(cleaned) > 6:
-        return f"{cleaned[:4]}***{cleaned[-2:]}"
-    return "***"
-
-
 class KOSPI200FuturesMonitor:
     """KOSPI200 Futures real-time monitor with anomaly detection"""
     


### PR DESCRIPTION
## Summary
- centralize the secret masking helpers under `utils.masking` so they can be reused across modules
- update the DB증권 WebSocket monitor and router alert callback to consume the shared masking utilities
- sanitize token manager logging output by masking sensitive response payloads before logging

## Testing
- `PYTHONPATH=. pytest tests/test_dbsec_module.py` *(fails: async pytest plugin missing and environment-specific assertions)*

------
https://chatgpt.com/codex/tasks/task_e_68e0f228315c832692f9a0eb49278142