### PR TITLE
Add pytest-asyncio dependency for async tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ httpx==0.27.0
 websocket-client==1.7.0
 pytz>=2023.3                  # Timezone handling for trading sessions
 holidays>=0.57                # 휴일 처리 라이브러리
+pytest-asyncio>=0.21.0        # Async 테스트 환경 구성


### PR DESCRIPTION
## Summary
- add pytest-asyncio to the main requirements to support asynchronous pytest execution

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0f22b2be88326ab8a1ec1362aa1f0