### PR TITLE
Refine secret masking threshold handling

### DIFF
--- a/services/dbsec_ws.py
+++ b/services/dbsec_ws.py
@@ -44,9 +44,14 @@ def mask_secret(value: Optional[str]) -> str:
     if not cleaned:
         return "***"
 
-    if len(cleaned) > 6:
-        return f"{cleaned[:4]}***{cleaned[-2:]}"
-    return "***"
+    head_visible = 4
+    tail_visible = 2
+    mask_token = "***"
+
+    if len(cleaned) <= head_visible + tail_visible + len(mask_token):
+        return mask_token
+
+    return f"{cleaned[:head_visible]}{mask_token}{cleaned[-tail_visible:]}"
 
 
 class KOSPI200FuturesMonitor:

--- a/tests/test_dbsec_module.py
+++ b/tests/test_dbsec_module.py
@@ -321,6 +321,13 @@ class TestSecretMasking:
 
         assert masked == "***"
 
+    def test_mask_secret_threshold_behaviour(self):
+        """Ensure secrets at the visibility threshold stay hidden."""
+        secret = "abcd123xy"  # length 9 == 4 + 2 + 3
+        masked = mask_secret(secret)
+
+        assert masked == "***"
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/utils/masking.py
+++ b/utils/masking.py
@@ -51,10 +51,12 @@ def mask_secret(value: Any, prefix_visible: int = 4, suffix_visible: int = 2) ->
     if prefix_visible <= 0 or suffix_visible <= 0:
         return "***"
 
-    if len(cleaned) <= prefix_visible + suffix_visible:
-        return "***"
+    mask_token = "***"
 
-    return f"{cleaned[:prefix_visible]}***{cleaned[-suffix_visible:]}"
+    if len(cleaned) <= prefix_visible + suffix_visible + len(mask_token):
+        return mask_token
+
+    return f"{cleaned[:prefix_visible]}{mask_token}{cleaned[-suffix_visible:]}"
 
 
 def redact_kv(


### PR DESCRIPTION
## Summary
- update the DB SEC WebSocket secret masker to fully hide short credentials
- align the shared masking helper with the new threshold requirement
- extend secret masking tests to cover the edge threshold behaviour

## Testing
- pytest tests/test_dbsec_module.py *(fails: async fixtures require pytest-asyncio plugin in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0f5652f5c832693472b1094f93202