### PR TITLE
Refactor masking helpers into shared utility

### DIFF
--- a/services/dbsec_ws.py
+++ b/services/dbsec_ws.py
@@ -19,40 +19,10 @@ from websocket._exceptions import (
 )
 import requests
 
-from utils.masking import redact_headers, redact_ws_url, redact_dict
+from utils.masking import mask_secret, redact_headers, redact_ws_url, redact_dict
 from utils.token_manager import get_token_manager
 
 logger = logging.getLogger(__name__)
-
-
-def mask_secret(value: Optional[str]) -> str:
-    """Mask sensitive credentials for safe logging."""
-    # 입력 값이 비어 있으면 완전 마스킹 처리
-    if value is None:
-        return "***"
-
-    try:
-        if isinstance(value, bytes):
-            value = value.decode("utf-8", "ignore")
-        elif not isinstance(value, str):
-            value = str(value)
-    except Exception as error:  # pragma: no cover - 방어적 로깅
-        logger.warning("Failed to normalize secret for masking: %s", error)
-        return "***"
-
-    cleaned = value.strip()
-    if not cleaned:
-        return "***"
-
-    head_visible = 4
-    tail_visible = 2
-    mask_token = "***"
-
-    if len(cleaned) <= head_visible + tail_visible + len(mask_token):
-        return mask_token
-
-    return f"{cleaned[:head_visible]}{mask_token}{cleaned[-tail_visible:]}"
-
 
 class KOSPI200FuturesMonitor:
     """KOSPI200 Futures real-time monitor with anomaly detection"""

--- a/utils/masking.py
+++ b/utils/masking.py
@@ -1,8 +1,11 @@
 """Utility helpers for masking sensitive values in logs and telemetry."""
 from __future__ import annotations
 
+import logging
 from typing import Any, Dict, Mapping, Sequence
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+
+logger = logging.getLogger(__name__)
 
 # 민감한 키 식별을 위한 기준 목록
 SENSITIVE_KEYS: Sequence[str] = (
@@ -41,7 +44,8 @@ def mask_secret(value: Any, prefix_visible: int = 4, suffix_visible: int = 2) ->
             value_str = value.decode("utf-8", "ignore")
         else:
             value_str = str(value)
-    except Exception:  # pragma: no cover - 방어적 처리
+    except Exception as error:  # pragma: no cover - 방어적 로깅
+        logger.warning("Failed to normalize secret for masking: %s", error)
         return "***"
 
     cleaned = value_str.strip()


### PR DESCRIPTION
## Summary
- enhance the shared masking helpers with defensive logging for normalization failures
- update the DB증권 WebSocket service to reuse the centralized masking utilities instead of defining local helpers

## Testing
- pytest tests/test_dbsec_module.py *(fails: pytest lacks async plugin support in this environment and an environment-dependent WebSocket URL assertion)*

------
https://chatgpt.com/codex/tasks/task_e_68e0f9327f9c8326849dcb77a0ce7d0c