### PR TITLE
Refine DBSEC logging granularity

### DIFF
--- a/services/dbsec_ws.py
+++ b/services/dbsec_ws.py
@@ -261,7 +261,15 @@ class KOSPI200FuturesMonitor:
             }
 
             logger.info(
-                "[DBSEC] K200 Futures tick: %s",
+                "[DBSEC] K200 Futures tick: price=%s change_rate=%s volume=%s session=%s",
+                tick_summary.get("price"),
+                tick_summary.get("change_rate"),
+                tick_summary.get("volume"),
+                tick_summary.get("session"),
+            )
+
+            logger.debug(
+                "[DBSEC] Tick summary (redacted): %s",
                 redact_dict(tick_summary),
             )
 


### PR DESCRIPTION
## Summary
- standardize the DBSEC subscription log message for K200 futures
- reduce INFO-level verbosity for tick updates while preserving redacted payloads at DEBUG level

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0fb6841e48326b2c86a83cffd86c2