### PR TITLE
Enforce consistent secret masking format

### DIFF
--- a/tests/test_dbsec_module.py
+++ b/tests/test_dbsec_module.py
@@ -332,6 +332,13 @@ class TestSecretMasking:
 
         assert masked == "***"
 
+    def test_mask_secret_fixed_pattern(self):
+        """Ensure custom head/tail arguments do not alter the mask pattern."""
+        secret = "abcdefghijklmnop"
+        masked = mask_secret(secret, head=1, tail=5)
+
+        assert masked == secret[:4] + "***" + secret[-2:]
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/utils/masking.py
+++ b/utils/masking.py
@@ -31,7 +31,7 @@ def _is_sensitive_key(key: str) -> bool:
 
 
 def mask_secret(value: Any, head: int = 4, tail: int = 2) -> str:
-    """Mask sensitive values following the 4-***-2 visibility pattern."""
+    """Mask sensitive values with a fixed 4-***-2 visibility pattern."""
     mask_token = "***"
 
     if value is None:
@@ -55,14 +55,12 @@ def mask_secret(value: Any, head: int = 4, tail: int = 2) -> str:
 
     visible_head = head if head > 0 else 0
     visible_tail = tail if tail > 0 else 0
-    threshold = visible_head + visible_tail + 3
+    threshold = visible_head + visible_tail + len(mask_token)
 
     if len(cleaned) <= threshold:
         return mask_token
 
-    prefix = cleaned[:visible_head] if visible_head else ""
-    suffix = cleaned[-visible_tail:] if visible_tail else ""
-    return f"{prefix}{mask_token}{suffix}"
+    return f"{cleaned[:4]}{mask_token}{cleaned[-2:]}"
 
 
 def redact_kv(


### PR DESCRIPTION
## Summary
- enforce a fixed 4-***-2 pattern in `mask_secret`, masking short inputs entirely
- add coverage to confirm custom head/tail hints no longer affect the masked output

## Testing
- pytest tests/test_dbsec_module.py

------
https://chatgpt.com/codex/tasks/task_e_68e10ecfdc108326be9c0b4b718a436a