### PR TITLE
Handle DBSEC websocket timeout with retry

### DIFF
--- a/services/dbsec_ws.py
+++ b/services/dbsec_ws.py
@@ -144,6 +144,12 @@ class KOSPI200FuturesMonitor:
             try:
                 await self._connect_and_monitor()
 
+            except asyncio.TimeoutError:
+                logger.warning("[DBSEC] WebSocket timeout, retrying...")
+                self.is_connected = False
+                await asyncio.sleep(5)
+                continue
+
             except (WebSocketConnectionClosedException, WebSocketException) as e:
                 self.reconnect_attempts += 1
                 logger.warning(f"WebSocket connection lost (attempt {self.reconnect_attempts}): {e}")


### PR DESCRIPTION
## Summary
- add retry handling for asyncio timeouts in the DBSEC futures monitor loop to keep the container alive

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e10ed431c48326913ce442e5c2ffd2