### PR TITLE
Improve DBSEC session gating and timeout handling

### DIFF
--- a/services/dbsec_ws.py
+++ b/services/dbsec_ws.py
@@ -134,12 +134,16 @@ class KOSPI200FuturesMonitor:
         logger.info("[DB증권] Starting K200 Futures monitoring")
         
         while True:
-            if not is_trading_session():
-                logger.info("[DBSEC] 휴장일/비거래 시간 → WebSocket 연결 skip (대기)")
+            session = determine_trading_session()
+            if session == "CLOSED":
+                logger.info("[DBSEC] 휴장일/비거래 시간 → WebSocket 연결 skip (30분 후 재확인)")
                 self.is_connected = False
                 self.reconnect_attempts = 0
-                await asyncio.sleep(60)
+                await asyncio.sleep(1800)
                 continue
+
+            if session in {"DAY", "NIGHT"} and session != self.current_session:
+                self.current_session = session
 
             try:
                 await self._connect_and_monitor()

--- a/tests/test_dbsec_module.py
+++ b/tests/test_dbsec_module.py
@@ -283,7 +283,7 @@ class TestWebSocketReconnection:
             mock_tm._is_in_backoff.return_value = False
             mock_token_mgr.return_value = mock_tm
 
-            with patch('services.dbsec_ws.is_trading_session', return_value=True), \
+            with patch('services.dbsec_ws.determine_trading_session', return_value="DAY"), \
                  patch('services.dbsec_ws.websocket.create_connection') as mock_ws:
                 # Simulate connection error then success
                 mock_ws.side_effect = [


### PR DESCRIPTION
## Summary
- add an explicit KRX trading-session gate before initiating DBSEC monitoring, skipping closed periods for 30 minutes before retrying
- ensure the session tracking updates while connected and adjust tests to mock the session detector

## Testing
- pytest tests/test_dbsec_module.py::TestWebSocketReconnection::test_reconnect_on_connection_lost -q

------
https://chatgpt.com/codex/tasks/task_e_68e1274706b08326ac2cd35bbb9649c4