### PR TITLE
Add masking and session utility test coverage

### DIFF
--- a/test_token.py
+++ b/test_token.py
@@ -8,6 +8,10 @@ import os
 import logging
 import sys
 
+import pytest
+
+pytestmark = pytest.mark.skip(reason="Manual DB증권 token test is excluded from automated pytest runs.")
+
 # Setup logging
 logging.basicConfig(
     level=logging.DEBUG,

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -1,0 +1,87 @@
+"""Unit tests for masking helpers used throughout the project."""
+from urllib.parse import parse_qs, urlparse
+
+from utils.masking import mask_secret, redact_dict, redact_headers, redact_ws_url
+
+
+class TestMaskSecret:
+    """Validate the core mask_secret behaviour including guard rails."""
+
+    def test_mask_secret_returns_mask_for_none(self):
+        """Ensure None input is masked by the default token."""
+        assert mask_secret(None) == "***"
+
+    def test_mask_secret_masks_short_values(self):
+        """Ensure short strings trigger the guard and return the mask token."""
+        assert mask_secret("abcd123") == "***"
+
+    def test_mask_secret_masks_threshold_length(self):
+        """Ensure threshold-length secrets are not partially exposed."""
+        guarded = mask_secret("abcd123xy")
+        assert guarded == "***"
+
+    def test_mask_secret_masks_bytes_payload(self):
+        """Ensure bytes payloads are decoded then masked using the pattern."""
+        secret = b"abcd123456789"
+        masked = mask_secret(secret)
+        assert masked.startswith("abcd")
+        assert masked.endswith("89")
+        assert masked[4:7] == "***"
+
+
+class TestRedactionHelpers:
+    """Validate helpers that redact sensitive information in collections."""
+
+    def test_redact_ws_url_masks_sensitive_query_parameters(self):
+        """Ensure sensitive query params are masked within WebSocket URLs."""
+        url = "wss://example.com/socket?token=abcd123456&user_id=42"
+        redacted = redact_ws_url(url)
+        parsed = urlparse(redacted)
+        params = parse_qs(parsed.query)
+
+        assert params["token"][0].startswith("abcd")
+        assert params["token"][0].endswith("56")
+        assert params["token"][0][4:7] == "***"
+        assert params["user_id"][0] == "42"
+
+    def test_redact_ws_url_without_query_returns_original(self):
+        """Ensure URLs without queries remain untouched."""
+        url = "wss://example.com/socket"
+        assert redact_ws_url(url) == url
+
+    def test_redact_headers_masks_sensitive_values(self):
+        """Ensure headers containing sensitive keys are masked."""
+        headers = {
+            "Authorization": "Bearer abcd123456",
+            "X-Trace-Id": "trace-001",
+        }
+
+        redacted = redact_headers(headers)
+
+        assert redacted["Authorization"].startswith("Bear")
+        assert redacted["Authorization"].endswith("56")
+        assert redacted["Authorization"][4:7] == "***"
+        assert redacted["X-Trace-Id"] == "trace-001"
+
+    def test_redact_dict_masks_nested_structures(self):
+        """Ensure nested mappings and sequences are recursively masked."""
+        payload = {
+            "metadata": {"token": "abcd123456"},
+            "headers": {"Authorization": "Token qwerty098765"},
+            "values": [
+                {"password": "secretvalue", "app_key": "1234"},
+                "public",
+            ],
+        }
+
+        redacted = redact_dict(payload)
+
+        assert redacted["metadata"]["token"].startswith("abcd")
+        assert redacted["metadata"]["token"].endswith("56")
+        assert redacted["metadata"]["token"][4:7] == "***"
+        assert redacted["headers"]["Authorization"].startswith("Toke")
+        assert redacted["headers"]["Authorization"].endswith("65")
+        assert redacted["headers"]["Authorization"][4:7] == "***"
+        assert redacted["values"][0]["password"] == "secr***ue"
+        assert redacted["values"][0]["app_key"] == "***"
+        assert redacted["values"][1] == "public"

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,124 @@
+"""Validation tests for trading session utilities."""
+from datetime import date, datetime
+
+import pytest
+from zoneinfo import ZoneInfo
+
+from app import utils
+
+KST = ZoneInfo("Asia/Seoul")
+
+
+@pytest.fixture
+def trading_calendar(monkeypatch):
+    """Patch the trading calendar to use a deterministic set of active days."""
+    active_days = set()
+
+    def set_days(days):
+        active_days.clear()
+        active_days.update(days)
+
+    def fake_is_trading(day):
+        return day in active_days
+
+    monkeypatch.setattr(utils, "is_krx_trading_day", fake_is_trading)
+    return set_days
+
+
+class TestDetermineTradingSession:
+    """Verify determine_trading_session across session boundaries."""
+
+    def test_day_session_on_trading_day(self, trading_calendar):
+        """Ensure a trading day morning falls into the DAY session."""
+        trading_calendar({date(2024, 1, 2)})
+        now = datetime(2024, 1, 2, 9, 0, tzinfo=KST)
+
+        assert utils.determine_trading_session(now) == "DAY"
+
+    def test_evening_night_session(self, trading_calendar):
+        """Ensure evening times shift into the NIGHT session."""
+        trading_calendar({date(2024, 1, 2)})
+        now = datetime(2024, 1, 2, 18, 30, tzinfo=KST)
+
+        assert utils.determine_trading_session(now) == "NIGHT"
+
+    def test_early_morning_night_session(self, trading_calendar):
+        """Ensure post-midnight times still map to NIGHT for prior trading days."""
+        trading_calendar({date(2024, 1, 2)})
+        now = datetime(2024, 1, 3, 2, 0, tzinfo=KST)
+
+        assert utils.determine_trading_session(now) == "NIGHT"
+
+    def test_closed_on_weekend(self, trading_calendar):
+        """Ensure weekends are treated as closed regardless of time."""
+        trading_calendar({date(2024, 1, 5)})
+        now = datetime(2024, 1, 6, 10, 0, tzinfo=KST)
+
+        assert utils.determine_trading_session(now) == "CLOSED"
+
+    def test_closed_on_holiday(self, trading_calendar):
+        """Ensure holidays remain closed despite being within session hours."""
+        trading_calendar({date(2024, 1, 2)})
+        now = datetime(2024, 1, 1, 9, 30, tzinfo=KST)
+
+        assert utils.determine_trading_session(now) == "CLOSED"
+
+
+class TestComputeNextOpen:
+    """Verify compute_next_open_kst returns the next valid market opening."""
+
+    def test_pre_market_moves_to_day_open(self, trading_calendar):
+        """Ensure pre-market hours jump to the same day's opening bell."""
+        trading_calendar({date(2024, 1, 2), date(2024, 1, 3)})
+        now = datetime(2024, 1, 2, 8, 0, tzinfo=KST)
+
+        expected = datetime(2024, 1, 2, 9, 0, tzinfo=KST)
+        assert utils.compute_next_open_kst(now) == expected
+
+    def test_during_day_session_moves_to_night_open(self, trading_calendar):
+        """Ensure intra-day times point to the upcoming night session."""
+        trading_calendar({date(2024, 1, 2), date(2024, 1, 3)})
+        now = datetime(2024, 1, 2, 13, 0, tzinfo=KST)
+
+        expected = datetime(2024, 1, 2, 18, 0, tzinfo=KST)
+        assert utils.compute_next_open_kst(now) == expected
+
+    def test_during_night_session_advances_to_next_day(self, trading_calendar):
+        """Ensure active night trading advances to the next day session."""
+        trading_calendar({date(2024, 1, 2), date(2024, 1, 3)})
+        now = datetime(2024, 1, 2, 19, 30, tzinfo=KST)
+
+        expected = datetime(2024, 1, 3, 9, 0, tzinfo=KST)
+        assert utils.compute_next_open_kst(now) == expected
+
+    def test_weekend_midday_advances_to_next_trading_day(self, trading_calendar):
+        """Ensure weekends roll forward to the next trading morning."""
+        trading_calendar({date(2024, 1, 5), date(2024, 1, 8)})
+        now = datetime(2024, 1, 6, 10, 0, tzinfo=KST)
+
+        expected = datetime(2024, 1, 8, 9, 0, tzinfo=KST)
+        assert utils.compute_next_open_kst(now) == expected
+
+    def test_holiday_moves_to_following_trading_day(self, trading_calendar):
+        """Ensure holidays roll to the next available trading day."""
+        trading_calendar({date(2024, 1, 2), date(2024, 1, 3)})
+        now = datetime(2024, 1, 1, 11, 0, tzinfo=KST)
+
+        expected = datetime(2024, 1, 2, 9, 0, tzinfo=KST)
+        assert utils.compute_next_open_kst(now) == expected
+
+    def test_early_morning_after_closed_day_targets_same_day(self, trading_calendar):
+        """Ensure early mornings after a closed prior day point to the same day's open."""
+        trading_calendar({date(2024, 1, 8), date(2024, 1, 9)})
+        now = datetime(2024, 1, 8, 4, 0, tzinfo=KST)
+
+        expected = datetime(2024, 1, 8, 9, 0, tzinfo=KST)
+        assert utils.compute_next_open_kst(now) == expected
+
+    def test_weekend_night_session_advances_to_next_weekday(self, trading_calendar):
+        """Ensure weekend night trading advances to the following weekday morning."""
+        trading_calendar({date(2024, 1, 5), date(2024, 1, 8)})
+        now = datetime(2024, 1, 6, 2, 0, tzinfo=KST)
+
+        expected = datetime(2024, 1, 8, 9, 0, tzinfo=KST)
+        assert utils.compute_next_open_kst(now) == expected


### PR DESCRIPTION
## Summary
- add a `compute_next_open_kst` helper to align next-open calculations with the simplified KRX trading schedule
- extend masking coverage with dedicated tests for `mask_secret`, `redact_ws_url`, `redact_headers`, and `redact_dict`
- exercise trading session utilities across day, night, weekend, and holiday scenarios and skip the manual token script when running pytest

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e1382c741083269cdc92c18f6c4e46