### PR TITLE
Refine trading session helpers

### DIFF
--- a/routers/dbsec.py
+++ b/routers/dbsec.py
@@ -319,8 +319,7 @@ async def get_trading_sessions():
     from app.utils import determine_trading_session
 
     # 세션 정보는 공용 헬퍼로 판정
-    session_info = determine_trading_session()
-    current_session = session_info.get("session")
+    current_session = determine_trading_session()
 
     return {
         "current_session": current_session,


### PR DESCRIPTION
## Summary
- simplify `determine_trading_session` to return the active session label and eliminate circular dependencies
- enhance `compute_next_open_kst` and `sleep_until` to consistently target the next session start and update WebSocket session handling
- update routers and tests to consume the new helpers directly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e14104a3488326a243e25bdbc0a9ab