### PR TITLE
Improve coverage for trading session helpers

### DIFF
--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -127,3 +127,15 @@ class TestComputeNextOpen:
 
         expected = datetime(2024, 1, 8, 9, 0, tzinfo=KST)
         assert utils.compute_next_open_kst(now) == expected
+
+    def test_session_helpers_no_recursion(self, trading_calendar):
+        """Ensure helper functions cooperate without recursive loops."""
+        trading_calendar({date(2024, 1, 2), date(2024, 1, 3)})
+        now = datetime(2024, 1, 2, 14, 0, tzinfo=KST)
+
+        status = utils.determine_trading_session(now)
+        assert status["session"] == "DAY"
+        assert status["next_open"] == datetime(2024, 1, 2, 18, 0, tzinfo=KST)
+
+        follow_up_open = utils.compute_next_open_kst(status["next_open"])
+        assert follow_up_open == datetime(2024, 1, 3, 9, 0, tzinfo=KST)


### PR DESCRIPTION
## Summary
- update trading session helper tests to validate next_open contracts without monkeypatching compute_next_open_kst
- add an integration-style test ensuring determine_trading_session and compute_next_open_kst cooperate without recursion

## Testing
- pytest tests/test_dbsec_module.py::TestKOSPI200FuturesMonitor::test_determine_trading_session_helper -q
- pytest tests/test_session.py::TestComputeNextOpen::test_session_helpers_no_recursion -q

------
https://chatgpt.com/codex/tasks/task_e_68e145f192088326900a2151bc4c68f8